### PR TITLE
Remove Cargo.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-Cargo.lock


### PR DESCRIPTION
Applications should keep `Cargo.lock` under version control.